### PR TITLE
Change method of getting timestamps of uncommitted changes

### DIFF
--- a/aab/git.py
+++ b/aab/git.py
@@ -80,10 +80,11 @@ class Git(object):
     def modtime(self, version):
         if version == "dev":
             # Get timestamps of uncommitted changes and return the most recent.
-            # https://stackoverflow.com/a/14142413
             cmd = (
-                "git status -s | while read mode file;"
-                " do echo $(stat -c %Y $file); done"
+                # https://stackoverflow.com/a/4210072
+                "find . -type d \( -path ./.git -o -path ./build \) -prune -o "
+                # https://stackoverflow.com/a/7448828
+                "-exec stat --format '%Y' {} \;"
             )
             modtimes = call_shell(cmd).splitlines()
             # https://stackoverflow.com/a/12010656


### PR DESCRIPTION
#### Description
Got an error when building the dev version after deleting a file, because `stat` does not work on files that don't exist (duh).

Try this to get an idea of which file's timestamps are included:
`find . -type d \( -path ./.git -o -path ./build \) -prune -o -exec stat --format '%Y %n' {} \;`

I am not sure if you want to keep this code in the Git class, since it does not use git anymore.

#### Checklist:

- [x] I've read and understood the [contribution guidelines](https://github.com/glutanimate/anki-addon-builder/blob/master/CONTRIBUTING.md)
- [x] I've tested my changes by building at least one of the [add-ons that use aab](https://github.com/glutanimate/anki-addon-builder/network/dependents?package_id=UGFja2FnZS00MDE1ODkwOTY%3D) for **Anki 2.1**
- [x] I've tested that the packages produced by my modified branch of aab work with ~~the [latest version of Anki](https://apps.ankiweb.net#download)~~ Anki running from source: Version 2.1.20 (d428b3b4)