### PR TITLE
12: Improve Shell Calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can get an overview of all supported actions by accessing the built-in help:
 
 ```
 $ aab -h
-usage: aab [-h] [-v] [-s] {build,ui,clean} ...
+usage: aab [-h] [-v] {build,ui,clean} ...
 
 positional arguments:
     {build,ui,clean}
@@ -62,13 +62,14 @@ Each subcommand also comes with its own help screen, e.g.:
 ```
 $ aab build -h
 usage: aab build [-h] [-t {anki21,anki20,all}] [-d {local,ankiweb,all}]
+                 [-c | -w | -r]
                  [version]
 
 positional arguments:
   version               Version to build as a git reference (e.g. 'v1.2.0' or
-                        'd338f6405'). Special keywords: 'current' – latest
-                        commit, 'release' – latest tag. Leave empty to build
-                        latest tag.
+                        'd338f6405'). Special instructions can be given with
+                        the mutually exclusive '-c', '-w' or '-r' options.
+                        Leave empty to build latest tag ('-r').
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -76,6 +77,11 @@ optional arguments:
                         Anki version to build for
   -d {local,ankiweb,all}, --dist {local,ankiweb,all}
                         Distribution channel to build for
+  -c, --current-commit  Build the currently checked out commit.
+  -w, --working-directory
+                        Build the current working directory without the need
+                        of a commit. Useful for development.
+  -r, --release         Build the latest tag.
 ```
 
 #### Examples
@@ -83,7 +89,7 @@ optional arguments:
 _Build latest tagged add-on release_
 
 ```
-aab build -d local -t anki21 release
+aab build -d local -t anki21 --release
 ```
 
 or simply

--- a/aab/builder.py
+++ b/aab/builder.py
@@ -74,7 +74,9 @@ class AddonBuilder(object):
         self._special = special
         if special:
             if version:
-                logging.warning("Warning: A special option is given. Given version name will be ignored!")
+                logging.warning(
+                    "Warning: A special option is given. Given version name will be ignored!"
+                )
             self._version = Git().parse_version(special)
         elif not version:
             self._version = Git().parse_version(version)  # if version is empty
@@ -161,7 +163,9 @@ class AddonBuilder(object):
 
     def _write_manifest(self, disttype):
         logging.info("Writing manifest...")
-        contents = self._config.manifest(self._version, self._special, disttype=disttype)
+        contents = self._config.manifest(
+            self._version, self._special, disttype=disttype
+        )
         path = self._path_dist_module / "manifest.json"
         with path.open("w", encoding="utf-8") as f:
             f.write(

--- a/aab/cli.py
+++ b/aab/cli.py
@@ -68,8 +68,15 @@ def validate_cwd():
 def build(args):
     targets = [args.target] if args.target != "all" else Config()["targets"]
     dists = [args.dist] if args.dist != "all" else DIST_TYPES
+    special = None
+    if args.release:
+        special = "release"
+    elif args.current_commit:
+        special = "current"
+    elif args.working_directory:
+        special = "dev"
 
-    builder = AddonBuilder(version=args.version)
+    builder = AddonBuilder(version=args.version, special=special)
 
     cnt = 1
     total = len(targets) * len(dists)
@@ -145,10 +152,32 @@ def construct_parser():
         nargs="?",
         help="Version to build as a git reference "
         "(e.g. 'v1.2.0' or 'd338f6405'). "
-        "Special keywords: 'dev' - working directory, "
-        "'current' – latest commit, 'release' – latest tag. "
-        "Leave empty to build latest tag.",
+        "Special instructions can be given with the mutually "
+        "exclusive '-c', '-w' or '-r' options. "
+        "Leave empty to build latest tag ('-r').",
     )
+
+    build_group_options = build_group.add_mutually_exclusive_group()
+    build_group_options.add_argument(
+        "-c",
+        "--current-commit",
+        action='store_true',
+        help="Build the currently checked out commit."
+    )
+    build_group_options.add_argument(
+        "-w",
+        "--working-directory",
+        action='store_true',
+        help="Build the current working directory without "
+             "the need of a commit. Useful for development."
+    )
+    build_group_options.add_argument(
+        "-r",
+        "--release",
+        action='store_true',
+        help="Build the latest tag."
+    )
+
     build_group.set_defaults(func=build)
 
     ui_group = subparsers.add_parser(

--- a/aab/cli.py
+++ b/aab/cli.py
@@ -161,21 +161,18 @@ def construct_parser():
     build_group_options.add_argument(
         "-c",
         "--current-commit",
-        action='store_true',
-        help="Build the currently checked out commit."
+        action="store_true",
+        help="Build the currently checked out commit.",
     )
     build_group_options.add_argument(
         "-w",
         "--working-directory",
-        action='store_true',
+        action="store_true",
         help="Build the current working directory without "
-             "the need of a commit. Useful for development."
+        "the need of a commit. Useful for development.",
     )
     build_group_options.add_argument(
-        "-r",
-        "--release",
-        action='store_true',
-        help="Build the latest tag."
+        "-r", "--release", action="store_true", help="Build the latest tag."
     )
 
     build_group.set_defaults(func=build)

--- a/aab/config.py
+++ b/aab/config.py
@@ -89,7 +89,7 @@ class Config(UserDict):
             )
             raise
 
-    def manifest(self, version, disttype="local"):
+    def manifest(self, version, special, disttype="local"):
         config = self.data
         manifest = {
             "name": config["display_name"],
@@ -99,7 +99,7 @@ class Config(UserDict):
             "version": version,
             "homepage": config.get("homepage", ""),
             "conflicts": copy(config["conflicts"]),
-            "mod": Git().modtime(version),
+            "mod": Git().modtime(version, special),
         }
 
         # Update values for distribution type

--- a/aab/git.py
+++ b/aab/git.py
@@ -81,20 +81,22 @@ class Git(object):
     def modtime(self, version, special):
         if special == "dev":
             # Get timestamps of uncommitted changes and return the most recent.
-            cmd = (
-                "git status -z"  # -z formats the file names in a parsing friendly way
-            )
+            cmd = "git status -z"  # -z formats the file names in a parsing friendly way
             # get all files from git, separate the mode and get the mtime for every file if it exists;
             # git uses '\0' line endings, thus the last split field is empty;
             # if a file was moved or copied git uses two lines ('XY to\0from') and we have to discard the second
             modtimes = []
-            it = iter(call_shell(cmd).split('\0')[0:-1])
+            it = iter(call_shell(cmd).split("\0")[0:-1])
             for x in it:
                 mode, file = x[0:2], x[3:]
-                if 'R' in mode or 'C' in mode:
+                if "R" in mode or "C" in mode:
                     next(it)  # skip 'from'
                 modtimes.append(file)
             modtimes[:] = [os.path.getmtime(x) for x in modtimes if os.path.exists(x)]
             return int(max(modtimes))
         else:
-            return int(call_shell("git log -1 --no-patch --format=%ct {}".format(quote(version))))
+            return int(
+                call_shell(
+                    "git log -1 --no-patch --format=%ct {}".format(quote(version))
+                )
+            )

--- a/aab/ui.py
+++ b/aab/ui.py
@@ -169,7 +169,10 @@ class UIBuilder(object):
             logging.debug("Building element '%s'...", new_stem)
             # Use relative paths to improve readability of form header:
             cmd = "{env} {tool} -o {out_file} {in_file}".format(
-                env=env, tool=quote(tool), in_file=quote(relpath(in_file)), out_file=quote(relpath(out_file))
+                env=env,
+                tool=quote(tool),
+                in_file=quote(relpath(in_file)),
+                out_file=quote(relpath(out_file)),
             )
             call_shell(cmd)
 
@@ -189,7 +192,9 @@ class UIBuilder(object):
         return (
             '''eval "$(pyenv init -)"'''
             '''&& eval "$(pyenv virtualenv-init -)"'''
-            """&& pyenv activate {pyenv} > /dev/null 2>&1 &&""".format(pyenv=quote(pyenv))
+            """&& pyenv activate {pyenv} > /dev/null 2>&1 &&""".format(
+                pyenv=quote(pyenv)
+            )
         )
 
     def _get_format_dict(self):

--- a/aab/ui.py
+++ b/aab/ui.py
@@ -47,7 +47,7 @@ from whichcraft import which
 
 from . import PATH_DIST, __title__, __version__
 from .config import Config
-from .utils import relpath, call_shell
+from .utils import relpath, call_shell, quote
 
 _template_header = '''\
 # -*- coding: utf-8 -*-
@@ -168,8 +168,8 @@ class UIBuilder(object):
 
             logging.debug("Building element '%s'...", new_stem)
             # Use relative paths to improve readability of form header:
-            cmd = "{env} {tool} {in_file} -o {out_file}".format(
-                env=env, tool=tool, in_file=relpath(in_file), out_file=relpath(out_file)
+            cmd = "{env} {tool} -o {out_file} {in_file}".format(
+                env=env, tool=quote(tool), in_file=quote(relpath(in_file)), out_file=quote(relpath(out_file))
             )
             call_shell(cmd)
 
@@ -189,7 +189,7 @@ class UIBuilder(object):
         return (
             '''eval "$(pyenv init -)"'''
             '''&& eval "$(pyenv virtualenv-init -)"'''
-            """&& pyenv activate {pyenv} > /dev/null 2>&1 &&""".format(pyenv=pyenv)
+            """&& pyenv activate {pyenv} > /dev/null 2>&1 &&""".format(pyenv=quote(pyenv))
         )
 
     def _get_format_dict(self):

--- a/aab/utils.py
+++ b/aab/utils.py
@@ -76,7 +76,7 @@ def purge(path, patterns, recursive=False):
     pattern_string = " -o ".join("-name {}".format(quote(p)) for p in patterns)
     pattern_string = r"\( {} \)".format(pattern_string)
     depth = "-maxdepth 1" if not recursive else ""
-    cmd = 'find {path} {depth} {pattern_string} -delete'.format(
+    cmd = "find {path} {depth} {pattern_string} -delete".format(
         path=quote(path), depth=depth, pattern_string=pattern_string
     )
     return call_shell(cmd)
@@ -86,7 +86,7 @@ def copy_recursively(source, target):
     if not source or not target:
         return False
     return call_shell(
-        'cp -r -- {source} {target}'.format(source=quote(source), target=quote(target))
+        "cp -r -- {source} {target}".format(source=quote(source), target=quote(target))
     )
 
 

--- a/aab/utils.py
+++ b/aab/utils.py
@@ -39,6 +39,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import sys
 import subprocess
 import logging
+import pipes
 
 from . import PATH_ROOT
 
@@ -72,11 +73,11 @@ def purge(path, patterns, recursive=False):
     """
     if not path or not patterns:
         return False
-    pattern_string = " -o ".join("-name '{}'".format(p) for p in patterns)
-    pattern_string = "\( {} \)".format(pattern_string)
+    pattern_string = " -o ".join("-name {}".format(quote(p)) for p in patterns)
+    pattern_string = r"\( {} \)".format(pattern_string)
     depth = "-maxdepth 1" if not recursive else ""
-    cmd = 'find "{path}" {depth} {pattern_string} -delete'.format(
-        path=path, depth=depth, pattern_string=pattern_string
+    cmd = 'find {path} {depth} {pattern_string} -delete'.format(
+        path=quote(path), depth=depth, pattern_string=pattern_string
     )
     return call_shell(cmd)
 
@@ -85,8 +86,13 @@ def copy_recursively(source, target):
     if not source or not target:
         return False
     return call_shell(
-        'cp -r "{source}" "{target}"'.format(source=source, target=target)
+        'cp -r -- {source} {target}'.format(source=quote(source), target=quote(target))
     )
+
+
+def quote(s):
+    """Quotes the given argument for use in a shell."""
+    return pipes.quote(str(s))
 
 
 def relpath(path):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='aab',
-    version='0.1.4',
+    version='0.1.5',
     description='Anki Add-on Builder',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Fixes #12

I tried to fix the issue with the shadowed values in the following way:
* I added three new mutually exclusive options that must be used instead of the magic values:
        * Short `-r`, long `--release`: replaces `release` and builds the latest tag
        * Short `-c`, long `--current-commit`: replaces `current` and builds the latest commit
          I tried to make the option name a little bit more verbose, but that can be changed back if you don't like it.
        * Short `-w`, long: `--working-directory`: replaces `dev`
          `-d` was already taken.
* Using the old special values will now look for a git-object with that name like every other supplied version.
Currently this breaks compatibility with older versions. Thus I increased the version number.
It may be a good idea to improve backwards compatibility by checking whether the magic words are valid git-object and acting the old way otherwise. (This is still not 100% compatible.)
Maybe keeping the old behavior and adding options to force it to accept them as git-objects (like `--git-object`) would be also a solution.

I also improved and escaped a lot of shell calls:
* I added a new 'quote' function. This is just a wrapper around `pipes.quote`
* I added '--' whenever possible (and needed) to make it harder that directories etc. starting with `-` could be interpreted as option.
  Currently I didn't find a way to do this for `pyrcc`. It does not seem to provide a way to end the arguments.
* I replaced the shell call with the complex script for determining the `modtime` with a single call to `git status -z` (which is designed to be parsed by machines) and some Python code to parse it. Now files with strange names containing new lines and other whitespace or quotes should be processed correctly.
  I also directly fixed PR #11 from @zjosua in the Python code.

I also updated the documentation to use the new options and usage and added a comment to the trash patters because I thought it may be practical to know that these are used as arguments for a find command (if something weird happens).

Finally I also fixed some small formatting issues my IDE informed me about.

#### Checklist:
- [x] I've read and understood the [contribution guidelines](https://github.com/glutanimate/anki-addon-builder/blob/master/CONTRIBUTING.md)
- [x] I've tested my changes by building at least one of the [add-ons that use aab](https://github.com/glutanimate/anki-addon-builder/network/dependents?package_id=UGFja2FnZS00MDE1ODkwOTY%3D) for **Anki 2.1**
  *I did not check whether the UI-builder still works.* (I do not know an addon that needs it.)
- [x] I've tested that the packages produced by my modified branch of aab work with the [latest version of Anki](https://apps.ankiweb.net#download)