### PR TITLE
Building with uncommitted changes on MacOS and Windows

### DIFF
--- a/aab/git.py
+++ b/aab/git.py
@@ -37,6 +37,7 @@ Basic Git interface
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
+import re
 import sys
 
 from .utils import call_shell
@@ -104,9 +105,11 @@ class Git(object):
                     f" ({sys.platform}) isn't supported."
                 )
 
-            modtimes = call_shell(cmd).splitlines()
+            # Converting output of the form "M 1618523117 designer/options.ui"
+            # to just the timestamp
             # https://stackoverflow.com/a/12010656
-            modtimes = [int(modtime) for modtime in modtimes]
+            modtimes = [int(re.search(r"[\d]+", output).group())
+                        for output in call_shell(cmd).splitlines()]
             return max(modtimes)
         else:
             return int(call_shell("git log -1 -s --format=%ct {}".format(version)))


### PR DESCRIPTION
#### Description

`aab build dev` wasn't working for me on MacOS, because the command being executed to get timestamps of uncommitted changes was different. The original code had a link to [this StackOverflow post](https://stackoverflow.com/a/14142413), which conveniently lists the code that needs to be run on Linux, MacOS, and Windows to get timestamps. All this PR does is check for the user's OS, and run the appropriate command. This fixed the command for me on MacOS. I don't have access to a Windows computer, so I haven't tested it on there. 

Aside from that simple change, I also had to use a regex to extract the digits in the timestamp out from the entire command output. I'm not sure why this wasn't necessary before, so if this breaks something for someone else, please let me know. From my tests, though, the commands from the StackOverflow post print output in the form `M 1618523117 designer/options.ui`, so to convert it to an integer we'd have to pick out the part of the string that was an integer. 

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](https://github.com/glutanimate/anki-addon-builder/blob/master/CONTRIBUTING.md)
- [x] I've tested my changes by building at least one of the [add-ons that use aab](https://github.com/glutanimate/anki-addon-builder/network/dependents?package_id=UGFja2FnZS00MDE1ODkwOTY%3D) for **Anki 2.1**
- [x] I've tested that the packages produced by my modified branch of aab work with the [latest version of Anki](https://apps.ankiweb.net#download)