### PR TITLE
Don't try to create Qt compat shims when no forms were created

### DIFF
--- a/aab/builder.py
+++ b/aab/builder.py
@@ -118,9 +118,10 @@ class AddonBuilder:
         for qt_version in qt_versions:
             ui_builder.build(qt_version=qt_version, pyenv=pyenv)
 
-        logging.info("Writing Qt compatibility shim...")
-        ui_builder.create_qt_shim()
-        logging.info("Done.")
+        if ui_builder._gui_path.exists():
+            logging.info("Writing Qt compatibility shim...")
+            ui_builder.create_qt_shim()
+            logging.info("Done.")
 
     def package_dist(self, qt_versions: List[QtVersion], disttype="local"):
         return self._package(qt_versions, disttype)


### PR DESCRIPTION
#### Description

Trying to write Qt compat shims when no ui files were created results in this error:
```
zjosua@surfian:~/sw_dev/image-occlusion-enhanced$ aab build -t all -d local current
Anki Add-on Builder v1.0.0-dev.2

Copyright (C) 2016-2022  Aristotelis P. (Glutanimate)  <https://glutanimate.com>

This program comes with ABSOLUTELY NO WARRANTY;
This is free software, and you are welcome to redistribute it
under certain conditions; For details please see the LICENSE file.

=== Build task 1/1 ===

--- Building Image Occlusion Enhanced v1.3.0-alpha6-18-gb45453b for local ---

Preparing source tree for Image Occlusion Enhanced v1.3.0-alpha6-18-gb45453b ...
Cleaning repository...
Exporting Git archive...
Copying licenses...
Copying changelog...
Writing manifest...
Starting UI build tasks for target 'qt5'...
No Qt forms folder found under /home/zjosua/sw_dev/image-occlusion-enhanced/build/dist/designer. Skipping build.
Starting UI build tasks for target 'qt6'...
No Qt forms folder found under /home/zjosua/sw_dev/image-occlusion-enhanced/build/dist/designer. Skipping build.
Writing Qt compatibility shim...
Traceback (most recent call last):
  File "/home/zjosua/.local/bin/aab", line 8, in <module>
    sys.exit(main())
  File "/home/zjosua/.local/lib/python3.9/site-packages/aab/cli.py", line 310, in main
    args.func(args)
  File "/home/zjosua/.local/lib/python3.9/site-packages/aab/cli.py", line 92, in build
    builder.build(qt_versions=qt_versions, disttype=dist)
  File "/home/zjosua/.local/lib/python3.9/site-packages/aab/builder.py", line 89, in build
    self.build_dist(qt_versions=qt_versions, disttype=disttype, pyenv=pyenv)
  File "/home/zjosua/.local/lib/python3.9/site-packages/aab/builder.py", line 122, in build_dist
    ui_builder.create_qt_shim()
  File "/home/zjosua/.local/lib/python3.9/site-packages/aab/ui.py", line 169, in create_qt_shim
    with out_path.open("w", encoding="utf-8") as f:
  File "/usr/lib/python3.9/pathlib.py", line 1252, in open
    return io.open(self, mode, buffering, encoding, errors, newline,
  File "/usr/lib/python3.9/pathlib.py", line 1120, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/home/zjosua/sw_dev/image-occlusion-enhanced/build/dist/src/image_occlusion_enhanced/gui/forms/__init__.py'
```

#### Checklist:

- [x] I've read and understood the [contribution guidelines](https://github.com/glutanimate/anki-addon-builder/blob/master/CONTRIBUTING.md)
- [x] I've tested my changes by building at least one of the [add-ons that use aab](https://github.com/glutanimate/anki-addon-builder/network/dependents?package_id=UGFja2FnZS00MDE1ODkwOTY%3D) for **Anki 2.1**
- [x] I've tested that the packages produced by my modified branch of aab work with the [latest version of Anki](~~https://apps.ankiweb.net#download~~ Anki 2.1.50, running from source)