### PR TITLE
Find addon.json in root, not in dist

### DIFF
--- a/aab/ui.py
+++ b/aab/ui.py
@@ -42,7 +42,7 @@ from typing import List, Optional
 
 from whichcraft import which
 
-from . import PATH_DIST, __title__, __version__
+from . import PATH_DIST, PATH_ROOT, __title__, __version__
 from .config import Config
 from .legacy import QRCMigrator, QRCParser, QResourceDescriptor
 from .utils import call_shell
@@ -117,7 +117,7 @@ class UIBuilder:
 
     def __init__(self, root: Optional[Path] = None):
         self._root = root or PATH_DIST
-        self._config = Config(path=self._root / "addon.json")
+        self._config = Config(path=PATH_ROOT / "addon.json")
 
         self._gui_path: Path = self._root / "src" / self._config["module_name"] / "gui"
         self._resources_source_path = self._root / QT_RESOURCES_FOLDER_NAME


### PR DESCRIPTION
#### Description

Config() is getting a wrong path to find addon.json.
Also I feel like the name `self._root` in UIBuilder is misleading, since it is assigned `PATH_DIST`. `self._dist` or `self._dist_path` would be better suited imo.
<details>
<summary>Console output w/ error msg</summary>

```
zjosua@surfian:~/sw_dev/image-occlusion-enhanced$ aab build -t all -d local current
Anki Add-on Builder v1.0.0-dev.2

Copyright (C) 2016-2022  Aristotelis P. (Glutanimate)  <https://glutanimate.com>

This program comes with ABSOLUTELY NO WARRANTY;
This is free software, and you are welcome to redistribute it
under certain conditions; For details please see the LICENSE file.

Getting Git version info...

=== Build task 1/1 ===

--- Building Image Occlusion Enhanced v1.3.0-alpha6-18-gb45453b for local ---

Preparing source tree for Image Occlusion Enhanced v1.3.0-alpha6-18-gb45453b ...
Cleaning repository...
Exporting Git archive...
Copying licenses...
Copying changelog...
Writing manifest...
Error: Could not read 'addon.json'. Traceback follows below:

Traceback (most recent call last):
  File "/home/zjosua/.local/bin/aab", line 8, in <module>
    sys.exit(main())
  File "/home/zjosua/.local/lib/python3.9/site-packages/aab/cli.py", line 310, in main
    args.func(args)
  File "/home/zjosua/.local/lib/python3.9/site-packages/aab/cli.py", line 92, in build
    builder.build(qt_versions=qt_versions, disttype=dist)
  File "/home/zjosua/.local/lib/python3.9/site-packages/aab/builder.py", line 89, in build
    self.build_dist(qt_versions=qt_versions, disttype=disttype, pyenv=pyenv)
  File "/home/zjosua/.local/lib/python3.9/site-packages/aab/builder.py", line 116, in build_dist
    ui_builder = UIBuilder(root=PATH_DIST)
  File "/home/zjosua/.local/lib/python3.9/site-packages/aab/ui.py", line 120, in __init__
    self._config = Config(path=self._root / "addon.json")
  File "/home/zjosua/.local/lib/python3.9/site-packages/aab/config.py", line 61, in __init__
    with self._path.open(encoding="utf-8") as f:
  File "/usr/lib/python3.9/pathlib.py", line 1252, in open
    return io.open(self, mode, buffering, encoding, errors, newline,
  File "/usr/lib/python3.9/pathlib.py", line 1120, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/home/zjosua/sw_dev/image-occlusion-enhanced/build/dist/addon.json'
```
</details>

#### Checklist:

- [x] I've read and understood the [contribution guidelines](https://github.com/glutanimate/anki-addon-builder/blob/master/CONTRIBUTING.md)
- [x] I've tested my changes by building at least one of the [add-ons that use aab](https://github.com/glutanimate/anki-addon-builder/network/dependents?package_id=UGFja2FnZS00MDE1ODkwOTY%3D) for **Anki 2.1**
- [x] I've tested that the packages produced by my modified branch of aab work with the [latest version of Anki](~~https://apps.ankiweb.net#download~~ Anki v2.1.50, running from source)