### PR TITLE
Fix mac dev build

### DIFF
--- a/aab/git.py
+++ b/aab/git.py
@@ -35,7 +35,7 @@ Basic Git interface
 
 import logging
 
-from .utils import call_shell
+from .utils import call_shell, isMac
 
 
 class Git(object):
@@ -78,9 +78,10 @@ class Git(object):
         if version == "dev":
             # Get timestamps of uncommitted changes and return the most recent.
             # https://stackoverflow.com/a/14142413
+            statcmd = "stat -f %m" if isMac else "stat -c %Y"
             cmd = (
                 "git status -s | while read mode file;"
-                " do echo $(stat -c %Y $file); done"
+                f" do echo $({statcmd} $file); done"
             )
             modtimes = call_shell(cmd).splitlines()
             # https://stackoverflow.com/a/12010656

--- a/aab/git.py
+++ b/aab/git.py
@@ -85,7 +85,7 @@ class Git(object):
             )
             modtimes = call_shell(cmd).splitlines()
             # https://stackoverflow.com/a/12010656
-            modtimes = [int(modtime) for modtime in modtimes]
+            modtimes = [int(modtime) for modtime in modtimes if modtime != ""]
             return max(modtimes)
         else:
             return int(call_shell("git log -1 -s --format=%ct {}".format(version)))

--- a/aab/utils.py
+++ b/aab/utils.py
@@ -36,6 +36,7 @@ Utility functions
 import logging
 import subprocess
 import sys
+import platform
 
 from . import PATH_ROOT
 
@@ -84,3 +85,6 @@ def copy_recursively(source, target):
     return call_shell(
         'cp -r "{source}" "{target}"'.format(source=source, target=target)
     )
+
+
+isMac = platform.system() == "Darwin"


### PR DESCRIPTION
#### Description

OS X uses a different `stat` command. From what I can tell, `stat -f %m $file` should be the equivalent to `stat -c %Y $file`. This PR detects the OS, and choose which stat command to use.

Keep in mind that I only tested it on the mac. There shouldn't be any side effects in linux, but I haven't tested it.

[man OS X stat](https://ss64.com/osx/stat.html)
[man linux stat](https://man7.org/linux/man-pages/man1/stat.1.html)


#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](https://github.com/glutanimate/anki-addon-builder/blob/master/CONTRIBUTING.md)
- [x] I've tested my changes by building at least one of the [add-ons that use aab](https://github.com/glutanimate/anki-addon-builder/network/dependents?package_id=UGFja2FnZS00MDE1ODkwOTY%3D) for **Anki 2.1**
- [x] I've tested that the packages produced by my modified branch of aab work with the [latest version of Anki](https://apps.ankiweb.net#download)