### PR TITLE
Fix for when /designer doesn't exist

### DIFF
--- a/aab/ui.py
+++ b/aab/ui.py
@@ -161,6 +161,10 @@ class UIBuilder:
         logging.info("Done with all UI build tasks.")
 
     def create_qt_shim(self):
+        # Qt shims are not needed as there are no qt files
+        if not self._forms_out_path.is_dir():
+            return
+
         out_path = self._forms_out_path / "__init__.py"
         if out_path.exists():
             out_path.unlink()

--- a/aab/ui.py
+++ b/aab/ui.py
@@ -135,13 +135,6 @@ class UIBuilder:
         path_in = self._forms_source_path
         path_out = self._forms_out_path / qt_version_key
 
-        if not path_in.exists():
-            logging.warning(
-                f"No Qt forms folder found under {self._forms_source_path}. Skipping"
-                " build."
-            )
-            return
-
         if (
             self._resources_source_path.exists()
             and self._config.get("qt_resource_migration_mode") != "disabled"
@@ -149,6 +142,13 @@ class UIBuilder:
             resource_prefixes_to_replace = self._migrate_resources()
         else:
             resource_prefixes_to_replace = []
+
+        if not path_in.exists():
+            logging.warning(
+                f"No Qt forms folder found under {self._forms_source_path}. Skipping"
+                " build."
+            )
+            return
 
         self._build(
             path_in=path_in,


### PR DESCRIPTION
#### Description

When the add-on doesn't use a Qt ui file, and thus doesn't have a `/designer` directory, `aab build` results in an error. So this checks if `this._forms_out_path` exists before attempting to write to a file in the directory. 

Also, even if there is no `/designer` directory, the `.qrc` file in `/resources` should still be built. So I changed the order of checking if `/designer` exists to after building resources.


#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](https://github.com/glutanimate/anki-addon-builder/blob/master/CONTRIBUTING.md)
- [x] I've tested my changes by building at least one of the [add-ons that use aab](https://github.com/glutanimate/anki-addon-builder/network/dependents?package_id=UGFja2FnZS00MDE1ODkwOTY%3D) for **Anki 2.1**
- [x] I've tested that the packages produced by my modified branch of aab work with the [latest version of Anki](https://apps.ankiweb.net#download)