### PR TITLE
double quote folder paths in command creation

### DIFF
--- a/aab/git.py
+++ b/aab/git.py
@@ -66,10 +66,10 @@ class Git(object):
             # https://stackoverflow.com/a/12010656
             cmd = (
                 "stash=`git stash create`; git archive --format tar $stash |"
-                " tar -x -C {outdir}/".format(outdir=outdir)
+                ' tar -x -C "{outdir}/"'.format(outdir=outdir)
             )
         else:
-            cmd = "git archive --format tar {vers} | tar -x -C {outdir}/".format(
+            cmd = 'git archive --format tar {vers} | tar -x -C "{outdir}/"'.format(
                 vers=version, outdir=outdir
             )
         return call_shell(cmd)


### PR DESCRIPTION
#### Description

While trying to build an addon, i got this error because the path of the addons folder has some whitespace:

```
Preparing source tree for field-autocomplete 0.1 ...
Cleaning repository...
Exporting Git archive...
tar: Engineering/Anki/22-09-30-text-expander/build/dist: Not found in archive
tar: Exiting with failure status due to previous errors
Error while running command: 'git archive --format tar 0.1 | tar -x -C /hdd/Software Engineering/Anki/22-09-30-text-expander/build/dist/'
```
 
#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](https://github.com/glutanimate/anki-addon-builder/blob/master/CONTRIBUTING.md)
- [x] I've tested my changes by building at least one of the [add-ons that use aab](https://github.com/glutanimate/anki-addon-builder/network/dependents?package_id=UGFja2FnZS00MDE1ODkwOTY%3D) for **Anki 2.1**
- [x] I've tested that the packages produced by my modified branch of aab work with the [latest version of Anki](https://apps.ankiweb.net#download)